### PR TITLE
ZSH Plugin: Fast Syntax Highlighting

### DIFF
--- a/inventories/group_vars/all/vars.yaml
+++ b/inventories/group_vars/all/vars.yaml
@@ -57,7 +57,7 @@ zsh_p10k_users:
 
 zsh_plugins:
   - "zsh-autosuggestions"
-  - zsh-syntax-highlighting
+  - "zsh-fast-syntax-highlighting"
 
 zsh_plugins_path: "{{ item.username }}/.oh-my-zsh/custom/plugins"
 # The following script will help you to make use fzf for options like ctr+r in ZSH

--- a/roles/zsh/defaults/main.yaml
+++ b/roles/zsh/defaults/main.yaml
@@ -46,3 +46,4 @@ zsh_p10k_write_p10k_config: true
 
 # ZSH Plugins
 zsh_autosuggestions_repo_url: "https://github.com/zsh-users/zsh-autosuggestions.git"
+zsh_fast_syntax_highlighting_repo_url: "https://github.com/zdharma-continuum/fast-syntax-highlighting.git"

--- a/roles/zsh/tasks/install-zsh-plugins.yaml
+++ b/roles/zsh/tasks/install-zsh-plugins.yaml
@@ -8,3 +8,13 @@
     version: 'master'
   loop: "{{ zsh_users }}"
   when: "'zsh-autosuggestions' in zsh_plugins"
+
+- name: "INSTALLING - Plugin: ZSH Fast Syntax Highlighting"
+  ansible.builtin.git:
+    repo: "{{ zsh_fast_syntax_highlighting_repo_url }}"
+    dest: '~{{ zsh_plugins_path }}/fast-syntax-highlighting'
+    depth: '1'
+    update: false
+    version: 'master'
+  loop: "{{ zsh_users }}"
+  when: "'zsh-fast-syntax-highlighting' in zsh_plugins"

--- a/roles/zsh/templates/zshrc.j2
+++ b/roles/zsh/templates/zshrc.j2
@@ -34,9 +34,10 @@ zstyle ':omz:update' mode disabled
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
 # Custom Sources
-source "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k/powerlevel10k.zsh-theme"
-source $HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
 source $HOME/.aliases
+source "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k/powerlevel10k.zsh-theme"
+source "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh"
+source "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
 source {{ zsh_fzf_key_bindings_script }}
 source {{ zsh_fzf_autocompletion }}
 


### PR DESCRIPTION
**Scope**
- Add ZFSH: https://github.com/zdharma-continuum/fast-syntax-highlighting